### PR TITLE
Switch to API version 3.0

### DIFF
--- a/WB-weather/providers/WB-openweathermap.js
+++ b/WB-weather/providers/WB-openweathermap.js
@@ -7,7 +7,7 @@
 class WBOpenWeatherMap extends WBProvider {
 	constructor(config, delegate) {
 		super(config, delegate);
-		this.baseURL = "https://api.openweathermap.org/data/2.5/onecall";
+		this.baseURL = "https://api.openweathermap.org/data/3.0/onecall";
 		this.url = this.getQueryStringURL(this.baseURL, {
 			"lat": config.latitude,
 			"lon": config.longitude,


### PR DESCRIPTION
API 2.5 will be closed in June 2024: https://openweathermap.org/one-call-transfer